### PR TITLE
fix dataset reading on unix systems

### DIFF
--- a/meldataset.py
+++ b/meldataset.py
@@ -79,7 +79,7 @@ class FilePathDataset(torch.utils.data.Dataset):
         spect_params = SPECT_PARAMS
         mel_params = MEL_PARAMS
 
-        _data_list = [l[:-1].split('|') for l in data_list]
+        _data_list = [l.strip().split('|') for l in data_list]
         self.data_list = [data if len(data) == 3 else (*data, 0) for data in _data_list]
         self.text_cleaner = TextCleaner()
         self.sr = sr


### PR DESCRIPTION
i guess dropping the last char of each line was because of used code split by "\n" and on windows line breaks are "\r\n", causing `\r` to be an artifact in the training data

however on unix systems newlines are just `\n` and therefore this code mutated the speaker id, for one char length, removing it

making the code to fail, cause speaker id becomes `''`

fix will `.strip()` any whitespace before and after, so it should work on win and still work on unix