### PR TITLE
Add importables + Gradio GUI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,102 @@
+import gradio as gr
+import msinference
+import ljinference
+import torch
+import os
+from tortoise.utils.text import split_and_recombine_text
+import numpy as np
+import pickle
+theme = gr.themes.Base(
+    font=[gr.themes.GoogleFont('Libre Franklin'), gr.themes.GoogleFont('Public Sans'), 'system-ui', 'sans-serif'],
+)
+voicelist = ['f-us-1', 'f-us-2', 'f-us-3', 'f-us-4', 'm-us-1', 'm-us-2', 'm-us-3', 'm-us-4']
+voices = {}
+import phonemizer
+global_phonemizer = phonemizer.backend.EspeakBackend(language='en-us', preserve_punctuation=True,  with_stress=True)
+# todo: cache computed style, load using pickle
+# if os.path.exists('voices.pkl'):
+    # with open('voices.pkl', 'rb') as f:
+        # voices = pickle.load(f)
+# else:
+for v in voicelist:
+    voices[v] = msinference.compute_style(f'voices/{v}.wav')
+def synthesize(text, voice, lngsteps, password, progress=gr.Progress()):
+    if text.strip() == "":
+        raise gr.Error("You must enter some text")
+    if lngsteps > 25:
+        raise gr.Error("Max 25 steps")
+    if lngsteps < 5:
+        raise gr.Error("Min 5 steps")
+    texts = split_and_recombine_text(text)
+    v = voice.lower()
+    audios = []
+    for t in progress.tqdm(texts):
+        audios.append(msinference.inference(t, voices[v], alpha=0.3, beta=0.7, diffusion_steps=lngsteps, embedding_scale=1))
+    return (24000, np.concatenate(audios))
+def clsynthesize(text, voice, vcsteps):
+    if text.strip() == "":
+        raise gr.Error("You must enter some text")
+    # if global_phonemizer.phonemize([text]) > 300:
+    if len(text) > 400:
+        raise gr.Error("Text must be under 400 characters")
+    return (24000, msinference.inference(text, msinference.compute_style(voice), alpha=0.3, beta=0.7, diffusion_steps=vcsteps, embedding_scale=1))
+def ljsynthesize(text):
+    if text.strip() == "":
+        raise gr.Error("You must enter some text")
+    # if global_phonemizer.phonemize([text]) > 300:
+    if len(text) > 400:
+        raise gr.Error("Text must be under 400 characters")
+    noise = torch.randn(1,1,256).to('cuda' if torch.cuda.is_available() else 'cpu')
+    return (24000, ljinference.inference(text, noise, diffusion_steps=7, embedding_scale=1))
+
+
+with gr.Blocks() as vctk: # just realized it isn't vctk but libritts but i'm too lazy to change it rn
+    with gr.Row():
+        with gr.Column(scale=1):
+            inp = gr.Textbox(label="Text", info="What would you like StyleTTS 2 to read? It works better on full sentences.", interactive=True)
+            voice = gr.Dropdown(voicelist, label="Voice", info="Select a default voice.", value='m-us-2', interactive=True)
+            multispeakersteps = gr.Slider(minimum=5, maximum=15, value=7, step=1, label="Diffusion Steps", info="Higher = better quality, but slower", interactive=True)
+            # use_gruut = gr.Checkbox(label="Use alternate phonemizer (Gruut) - Experimental")
+        with gr.Column(scale=1):
+            btn = gr.Button("Synthesize", variant="primary")
+            audio = gr.Audio(interactive=False, label="Synthesized Audio")
+            btn.click(synthesize, inputs=[inp, voice, multispeakersteps], outputs=[audio], concurrency_limit=4)
+with gr.Blocks() as clone:
+    with gr.Row():
+        with gr.Column(scale=1):
+            clinp = gr.Textbox(label="Text", info="What would you like StyleTTS 2 to read? It works better on full sentences.", interactive=True)
+            clvoice = gr.Audio(label="Voice", interactive=True, type='filepath', max_length=300)
+            vcsteps = gr.Slider(minimum=5, maximum=20, value=20, step=1, label="Diffusion Steps", info="Higher = better quality, but slower", interactive=True)
+        with gr.Column(scale=1):
+            clbtn = gr.Button("Synthesize", variant="primary")
+            claudio = gr.Audio(interactive=False, label="Synthesized Audio")
+            clbtn.click(clsynthesize, inputs=[clinp, clvoice, vcsteps], outputs=[claudio], concurrency_limit=4)
+with gr.Blocks() as lj:
+    with gr.Row():
+        with gr.Column(scale=1):
+            ljinp = gr.Textbox(label="Text", info="What would you like StyleTTS 2 to read? It works better on full sentences.", interactive=True)
+        with gr.Column(scale=1):
+            ljbtn = gr.Button("Synthesize", variant="primary")
+            ljaudio = gr.Audio(interactive=False, label="Synthesized Audio")
+            ljbtn.click(ljsynthesize, inputs=[ljinp], outputs=[ljaudio], concurrency_limit=4)
+with gr.Blocks(title="StyleTTS 2", css="footer{display:none !important}", theme=theme) as demo:
+    gr.Markdown("""# StyleTTS 2
+
+[Paper](https://arxiv.org/abs/2306.07691) - [Samples](https://styletts2.github.io/) - [Code](https://github.com/yl4579/StyleTTS2)
+
+GUI of StyleTTS 2 by [mrfakename](https://twitter.com/realmrfakename).
+
+#### Help the StyleTTS 2 space get to the top of HF Trending! [Give it a Like!](https://huggingface.co/spaces/styletts2/styletts2)
+
+**Before using this demo, you agree to inform the listeners that the speech samples are synthesized by the pre-trained models, unless you have the permission to use the voice you synthesize. That is, you agree to only use voices whose speakers grant the permission to have their voice cloned, either directly or by license before making synthesized voices public, or you have to publicly announce that these voices are synthesized if you do not have the permission to use these voices.**
+
+**NOTE: StyleTTS 2 does better on longer texts.** For example, making it say "hi" will produce a lower-quality result than making it say a longer phrase.""")
+    gr.TabbedInterface([vctk, clone, lj], ['Multi-Voice', 'Voice Cloning', 'LJSpeech'])
+    gr.Markdown("""
+Demo by [mrfakename](https://twitter.com/realmrfakename). I am not affiliated with the StyleTTS 2 authors.
+
+This is the local version of the demo
+""")
+if __name__ == "__main__":
+    demo.queue(api_open=False, max_size=15).launch(show_api=False)
+

--- a/ljinference.py
+++ b/ljinference.py
@@ -1,0 +1,225 @@
+from cached_path import cached_path
+
+
+import torch
+torch.manual_seed(0)
+torch.backends.cudnn.benchmark = False
+torch.backends.cudnn.deterministic = True
+
+import random
+random.seed(0)
+
+import numpy as np
+np.random.seed(0)
+
+import nltk
+nltk.download('punkt')
+
+# load packages
+import time
+import random
+import yaml
+from munch import Munch
+import numpy as np
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torchaudio
+import librosa
+from nltk.tokenize import word_tokenize
+
+from models import *
+from utils import *
+from text_utils import TextCleaner
+textclenaer = TextCleaner()
+
+
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+to_mel = torchaudio.transforms.MelSpectrogram(
+    n_mels=80, n_fft=2048, win_length=1200, hop_length=300)
+mean, std = -4, 4
+
+def length_to_mask(lengths):
+    mask = torch.arange(lengths.max()).unsqueeze(0).expand(lengths.shape[0], -1).type_as(lengths)
+    mask = torch.gt(mask+1, lengths.unsqueeze(1))
+    return mask
+
+def preprocess(wave):
+    wave_tensor = torch.from_numpy(wave).float()
+    mel_tensor = to_mel(wave_tensor)
+    mel_tensor = (torch.log(1e-5 + mel_tensor.unsqueeze(0)) - mean) / std
+    return mel_tensor
+
+def compute_style(ref_dicts):
+    reference_embeddings = {}
+    for key, path in ref_dicts.items():
+        wave, sr = librosa.load(path, sr=24000)
+        audio, index = librosa.effects.trim(wave, top_db=30)
+        if sr != 24000:
+            audio = librosa.resample(audio, sr, 24000)
+        mel_tensor = preprocess(audio).to(device)
+
+        with torch.no_grad():
+            ref = model.style_encoder(mel_tensor.unsqueeze(1))
+        reference_embeddings[key] = (ref.squeeze(1), audio)
+
+    return reference_embeddings
+
+# load phonemizer
+import phonemizer
+global_phonemizer = phonemizer.backend.EspeakBackend(language='en-us', preserve_punctuation=True, with_stress=True, words_mismatch='ignore')
+
+# phonemizer = Phonemizer.from_checkpoint(str(cached_path('https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer/en_us_cmudict_ipa_forward.pt')))
+
+
+config = yaml.safe_load(open(str(cached_path('hf://yl4579/StyleTTS2-LJSpeech/Models/LJSpeech/config.yml'))))
+
+# load pretrained ASR model
+ASR_config = config.get('ASR_config', False)
+ASR_path = config.get('ASR_path', False)
+text_aligner = load_ASR_models(ASR_path, ASR_config)
+
+# load pretrained F0 model
+F0_path = config.get('F0_path', False)
+pitch_extractor = load_F0_models(F0_path)
+
+# load BERT model
+from Utils.PLBERT.util import load_plbert
+BERT_path = config.get('PLBERT_dir', False)
+plbert = load_plbert(BERT_path)
+
+model = build_model(recursive_munch(config['model_params']), text_aligner, pitch_extractor, plbert)
+_ = [model[key].eval() for key in model]
+_ = [model[key].to(device) for key in model]
+
+# params_whole = torch.load("Models/LJSpeech/epoch_2nd_00100.pth", map_location='cpu')
+params_whole = torch.load(str(cached_path('hf://yl4579/StyleTTS2-LJSpeech/Models/LJSpeech/epoch_2nd_00100.pth')), map_location='cpu')
+params = params_whole['net']
+
+for key in model:
+    if key in params:
+        print('%s loaded' % key)
+        try:
+            model[key].load_state_dict(params[key])
+        except:
+            from collections import OrderedDict
+            state_dict = params[key]
+            new_state_dict = OrderedDict()
+            for k, v in state_dict.items():
+                name = k[7:] # remove `module.`
+                new_state_dict[name] = v
+            # load params
+            model[key].load_state_dict(new_state_dict, strict=False)
+#             except:
+#                 _load(params[key], model[key])
+_ = [model[key].eval() for key in model]
+
+from Modules.diffusion.sampler import DiffusionSampler, ADPM2Sampler, KarrasSchedule
+
+sampler = DiffusionSampler(
+    model.diffusion.diffusion,
+    sampler=ADPM2Sampler(),
+    sigma_schedule=KarrasSchedule(sigma_min=0.0001, sigma_max=3.0, rho=9.0), # empirical parameters
+    clamp=False
+)
+
+def inference(text, noise, diffusion_steps=5, embedding_scale=1):
+    text = text.strip()
+    text = text.replace('"', '')
+    ps = global_phonemizer.phonemize([text])
+    ps = word_tokenize(ps[0])
+    ps = ' '.join(ps)
+
+    tokens = textclenaer(ps)
+    tokens.insert(0, 0)
+    tokens = torch.LongTensor(tokens).to(device).unsqueeze(0)
+
+    with torch.no_grad():
+        input_lengths = torch.LongTensor([tokens.shape[-1]]).to(tokens.device)
+        text_mask = length_to_mask(input_lengths).to(tokens.device)
+
+        t_en = model.text_encoder(tokens, input_lengths, text_mask)
+        bert_dur = model.bert(tokens, attention_mask=(~text_mask).int())
+        d_en = model.bert_encoder(bert_dur).transpose(-1, -2)
+
+        s_pred = sampler(noise,
+              embedding=bert_dur[0].unsqueeze(0), num_steps=diffusion_steps,
+              embedding_scale=embedding_scale).squeeze(0)
+
+        s = s_pred[:, 128:]
+        ref = s_pred[:, :128]
+
+        d = model.predictor.text_encoder(d_en, s, input_lengths, text_mask)
+
+        x, _ = model.predictor.lstm(d)
+        duration = model.predictor.duration_proj(x)
+        duration = torch.sigmoid(duration).sum(axis=-1)
+        pred_dur = torch.round(duration.squeeze()).clamp(min=1)
+
+        pred_dur[-1] += 5
+
+        pred_aln_trg = torch.zeros(input_lengths, int(pred_dur.sum().data))
+        c_frame = 0
+        for i in range(pred_aln_trg.size(0)):
+            pred_aln_trg[i, c_frame:c_frame + int(pred_dur[i].data)] = 1
+            c_frame += int(pred_dur[i].data)
+
+        # encode prosody
+        en = (d.transpose(-1, -2) @ pred_aln_trg.unsqueeze(0).to(device))
+        F0_pred, N_pred = model.predictor.F0Ntrain(en, s)
+        out = model.decoder((t_en @ pred_aln_trg.unsqueeze(0).to(device)),
+                                F0_pred, N_pred, ref.squeeze().unsqueeze(0))
+
+    return out.squeeze().cpu().numpy()
+
+def LFinference(text, s_prev, noise, alpha=0.7, diffusion_steps=5, embedding_scale=1):
+  text = text.strip()
+  text = text.replace('"', '')
+  ps = global_phonemizer.phonemize([text])
+  ps = word_tokenize(ps[0])
+  ps = ' '.join(ps)
+
+  tokens = textclenaer(ps)
+  tokens.insert(0, 0)
+  tokens = torch.LongTensor(tokens).to(device).unsqueeze(0)
+
+  with torch.no_grad():
+      input_lengths = torch.LongTensor([tokens.shape[-1]]).to(tokens.device)
+      text_mask = length_to_mask(input_lengths).to(tokens.device)
+
+      t_en = model.text_encoder(tokens, input_lengths, text_mask)
+      bert_dur = model.bert(tokens, attention_mask=(~text_mask).int())
+      d_en = model.bert_encoder(bert_dur).transpose(-1, -2)
+
+      s_pred = sampler(noise,
+            embedding=bert_dur[0].unsqueeze(0), num_steps=diffusion_steps,
+            embedding_scale=embedding_scale).squeeze(0)
+
+      if s_prev is not None:
+          # convex combination of previous and current style
+          s_pred = alpha * s_prev + (1 - alpha) * s_pred
+
+      s = s_pred[:, 128:]
+      ref = s_pred[:, :128]
+
+      d = model.predictor.text_encoder(d_en, s, input_lengths, text_mask)
+
+      x, _ = model.predictor.lstm(d)
+      duration = model.predictor.duration_proj(x)
+      duration = torch.sigmoid(duration).sum(axis=-1)
+      pred_dur = torch.round(duration.squeeze()).clamp(min=1)
+
+      pred_aln_trg = torch.zeros(input_lengths, int(pred_dur.sum().data))
+      c_frame = 0
+      for i in range(pred_aln_trg.size(0)):
+          pred_aln_trg[i, c_frame:c_frame + int(pred_dur[i].data)] = 1
+          c_frame += int(pred_dur[i].data)
+
+      # encode prosody
+      en = (d.transpose(-1, -2) @ pred_aln_trg.unsqueeze(0).to(device))
+      F0_pred, N_pred = model.predictor.F0Ntrain(en, s)
+      out = model.decoder((t_en @ pred_aln_trg.unsqueeze(0).to(device)),
+                              F0_pred, N_pred, ref.squeeze().unsqueeze(0))
+
+  return out.squeeze().cpu().numpy(), s_pred

--- a/msinference.py
+++ b/msinference.py
@@ -1,0 +1,356 @@
+from cached_path import cached_path
+import nltk
+nltk.download('punkt')
+from scipy.io.wavfile import write
+import torch
+torch.manual_seed(0)
+torch.backends.cudnn.benchmark = False
+torch.backends.cudnn.deterministic = True
+
+import random
+random.seed(0)
+
+import numpy as np
+np.random.seed(0)
+
+# load packages
+import time
+import random
+import yaml
+from munch import Munch
+import numpy as np
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torchaudio
+import librosa
+from nltk.tokenize import word_tokenize
+
+from models import *
+from utils import *
+from text_utils import TextCleaner
+textclenaer = TextCleaner()
+
+
+to_mel = torchaudio.transforms.MelSpectrogram(
+    n_mels=80, n_fft=2048, win_length=1200, hop_length=300)
+mean, std = -4, 4
+
+def length_to_mask(lengths):
+    mask = torch.arange(lengths.max()).unsqueeze(0).expand(lengths.shape[0], -1).type_as(lengths)
+    mask = torch.gt(mask+1, lengths.unsqueeze(1))
+    return mask
+
+def preprocess(wave):
+    wave_tensor = torch.from_numpy(wave).float()
+    mel_tensor = to_mel(wave_tensor)
+    mel_tensor = (torch.log(1e-5 + mel_tensor.unsqueeze(0)) - mean) / std
+    return mel_tensor
+
+def compute_style(path):
+    wave, sr = librosa.load(path, sr=24000)
+    audio, index = librosa.effects.trim(wave, top_db=30)
+    if sr != 24000:
+        audio = librosa.resample(audio, sr, 24000)
+    mel_tensor = preprocess(audio).to(device)
+
+    with torch.no_grad():
+        ref_s = model.style_encoder(mel_tensor.unsqueeze(1))
+        ref_p = model.predictor_encoder(mel_tensor.unsqueeze(1))
+
+    return torch.cat([ref_s, ref_p], dim=1)
+
+device = 'cpu'
+if torch.cuda.is_available():
+    device = 'cuda'
+elif torch.backends.mps.is_available():
+    # print("MPS would be available but cannot be used rn")
+    pass
+    # device = 'mps'
+
+import phonemizer
+global_phonemizer = phonemizer.backend.EspeakBackend(language='en-us', preserve_punctuation=True,  with_stress=True)
+# phonemizer = Phonemizer.from_checkpoint(str(cached_path('https://public-asai-dl-models.s3.eu-central-1.amazonaws.com/DeepPhonemizer/en_us_cmudict_ipa_forward.pt')))
+
+
+# config = yaml.safe_load(open("Models/LibriTTS/config.yml"))
+config = yaml.safe_load(open(str(cached_path("hf://yl4579/StyleTTS2-LibriTTS/Models/LibriTTS/config.yml"))))
+
+# load pretrained ASR model
+ASR_config = config.get('ASR_config', False)
+ASR_path = config.get('ASR_path', False)
+text_aligner = load_ASR_models(ASR_path, ASR_config)
+
+# load pretrained F0 model
+F0_path = config.get('F0_path', False)
+pitch_extractor = load_F0_models(F0_path)
+
+# load BERT model
+from Utils.PLBERT.util import load_plbert
+BERT_path = config.get('PLBERT_dir', False)
+plbert = load_plbert(BERT_path)
+
+model_params = recursive_munch(config['model_params'])
+model = build_model(model_params, text_aligner, pitch_extractor, plbert)
+_ = [model[key].eval() for key in model]
+_ = [model[key].to(device) for key in model]
+
+# params_whole = torch.load("Models/LibriTTS/epochs_2nd_00020.pth", map_location='cpu')
+params_whole = torch.load(str(cached_path("hf://yl4579/StyleTTS2-LibriTTS/Models/LibriTTS/epochs_2nd_00020.pth")), map_location='cpu')
+params = params_whole['net']
+
+for key in model:
+    if key in params:
+        print('%s loaded' % key)
+        try:
+            model[key].load_state_dict(params[key])
+        except:
+            from collections import OrderedDict
+            state_dict = params[key]
+            new_state_dict = OrderedDict()
+            for k, v in state_dict.items():
+                name = k[7:] # remove `module.`
+                new_state_dict[name] = v
+            # load params
+            model[key].load_state_dict(new_state_dict, strict=False)
+#             except:
+#                 _load(params[key], model[key])
+_ = [model[key].eval() for key in model]
+
+from Modules.diffusion.sampler import DiffusionSampler, ADPM2Sampler, KarrasSchedule
+
+sampler = DiffusionSampler(
+    model.diffusion.diffusion,
+    sampler=ADPM2Sampler(),
+    sigma_schedule=KarrasSchedule(sigma_min=0.0001, sigma_max=3.0, rho=9.0), # empirical parameters
+    clamp=False
+)
+
+def inference(text, ref_s, alpha = 0.3, beta = 0.7, diffusion_steps=5, embedding_scale=1, use_gruut=False):
+    text = text.strip()
+    ps = global_phonemizer.phonemize([text])
+    ps = word_tokenize(ps[0])
+    ps = ' '.join(ps)
+    tokens = textclenaer(ps)
+    tokens.insert(0, 0)
+    tokens = torch.LongTensor(tokens).to(device).unsqueeze(0)
+
+    with torch.no_grad():
+        input_lengths = torch.LongTensor([tokens.shape[-1]]).to(device)
+        text_mask = length_to_mask(input_lengths).to(device)
+
+        t_en = model.text_encoder(tokens, input_lengths, text_mask)
+        bert_dur = model.bert(tokens, attention_mask=(~text_mask).int())
+        d_en = model.bert_encoder(bert_dur).transpose(-1, -2)
+
+        s_pred = sampler(noise = torch.randn((1, 256)).unsqueeze(1).to(device),
+                                          embedding=bert_dur,
+                                          embedding_scale=embedding_scale,
+                                            features=ref_s, # reference from the same speaker as the embedding
+                                             num_steps=diffusion_steps).squeeze(1)
+
+
+        s = s_pred[:, 128:]
+        ref = s_pred[:, :128]
+
+        ref = alpha * ref + (1 - alpha)  * ref_s[:, :128]
+        s = beta * s + (1 - beta)  * ref_s[:, 128:]
+
+        d = model.predictor.text_encoder(d_en,
+                                         s, input_lengths, text_mask)
+
+        x, _ = model.predictor.lstm(d)
+        duration = model.predictor.duration_proj(x)
+
+        duration = torch.sigmoid(duration).sum(axis=-1)
+        pred_dur = torch.round(duration.squeeze()).clamp(min=1)
+
+
+        pred_aln_trg = torch.zeros(input_lengths, int(pred_dur.sum().data))
+        c_frame = 0
+        for i in range(pred_aln_trg.size(0)):
+            pred_aln_trg[i, c_frame:c_frame + int(pred_dur[i].data)] = 1
+            c_frame += int(pred_dur[i].data)
+
+        # encode prosody
+        en = (d.transpose(-1, -2) @ pred_aln_trg.unsqueeze(0).to(device))
+        if model_params.decoder.type == "hifigan":
+            asr_new = torch.zeros_like(en)
+            asr_new[:, :, 0] = en[:, :, 0]
+            asr_new[:, :, 1:] = en[:, :, 0:-1]
+            en = asr_new
+
+        F0_pred, N_pred = model.predictor.F0Ntrain(en, s)
+
+        asr = (t_en @ pred_aln_trg.unsqueeze(0).to(device))
+        if model_params.decoder.type == "hifigan":
+            asr_new = torch.zeros_like(asr)
+            asr_new[:, :, 0] = asr[:, :, 0]
+            asr_new[:, :, 1:] = asr[:, :, 0:-1]
+            asr = asr_new
+
+        out = model.decoder(asr,
+                                F0_pred, N_pred, ref.squeeze().unsqueeze(0))
+
+
+    return out.squeeze().cpu().numpy()[..., :-50] # weird pulse at the end of the model, need to be fixed later
+
+def LFinference(text, s_prev, ref_s, alpha = 0.3, beta = 0.7, t = 0.7, diffusion_steps=5, embedding_scale=1, use_gruut=False):
+    text = text.strip()
+    ps = global_phonemizer.phonemize([text])
+    ps = word_tokenize(ps[0])
+    ps = ' '.join(ps)
+    ps = ps.replace('``', '"')
+    ps = ps.replace("''", '"')
+
+    tokens = textclenaer(ps)
+    tokens.insert(0, 0)
+    tokens = torch.LongTensor(tokens).to(device).unsqueeze(0)
+
+    with torch.no_grad():
+        input_lengths = torch.LongTensor([tokens.shape[-1]]).to(device)
+        text_mask = length_to_mask(input_lengths).to(device)
+
+        t_en = model.text_encoder(tokens, input_lengths, text_mask)
+        bert_dur = model.bert(tokens, attention_mask=(~text_mask).int())
+        d_en = model.bert_encoder(bert_dur).transpose(-1, -2)
+
+        s_pred = sampler(noise = torch.randn((1, 256)).unsqueeze(1).to(device),
+                                        embedding=bert_dur,
+                                        embedding_scale=embedding_scale,
+                                            features=ref_s, # reference from the same speaker as the embedding
+                                            num_steps=diffusion_steps).squeeze(1)
+
+        if s_prev is not None:
+            # convex combination of previous and current style
+            s_pred = t * s_prev + (1 - t) * s_pred
+
+        s = s_pred[:, 128:]
+        ref = s_pred[:, :128]
+
+        ref = alpha * ref + (1 - alpha)  * ref_s[:, :128]
+        s = beta * s + (1 - beta)  * ref_s[:, 128:]
+
+        s_pred = torch.cat([ref, s], dim=-1)
+
+        d = model.predictor.text_encoder(d_en,
+                                        s, input_lengths, text_mask)
+
+        x, _ = model.predictor.lstm(d)
+        duration = model.predictor.duration_proj(x)
+
+        duration = torch.sigmoid(duration).sum(axis=-1)
+        pred_dur = torch.round(duration.squeeze()).clamp(min=1)
+
+
+        pred_aln_trg = torch.zeros(input_lengths, int(pred_dur.sum().data))
+        c_frame = 0
+        for i in range(pred_aln_trg.size(0)):
+            pred_aln_trg[i, c_frame:c_frame + int(pred_dur[i].data)] = 1
+            c_frame += int(pred_dur[i].data)
+
+        # encode prosody
+        en = (d.transpose(-1, -2) @ pred_aln_trg.unsqueeze(0).to(device))
+        if model_params.decoder.type == "hifigan":
+            asr_new = torch.zeros_like(en)
+            asr_new[:, :, 0] = en[:, :, 0]
+            asr_new[:, :, 1:] = en[:, :, 0:-1]
+            en = asr_new
+
+        F0_pred, N_pred = model.predictor.F0Ntrain(en, s)
+
+        asr = (t_en @ pred_aln_trg.unsqueeze(0).to(device))
+        if model_params.decoder.type == "hifigan":
+            asr_new = torch.zeros_like(asr)
+            asr_new[:, :, 0] = asr[:, :, 0]
+            asr_new[:, :, 1:] = asr[:, :, 0:-1]
+            asr = asr_new
+
+        out = model.decoder(asr,
+                                F0_pred, N_pred, ref.squeeze().unsqueeze(0))
+
+
+    return out.squeeze().cpu().numpy()[..., :-100], s_pred # weird pulse at the end of the model, need to be fixed later
+
+def STinference(text, ref_s, ref_text, alpha = 0.3, beta = 0.7, diffusion_steps=5, embedding_scale=1, use_gruut=False):
+    text = text.strip()
+    ps = global_phonemizer.phonemize([text])
+    ps = word_tokenize(ps[0])
+    ps = ' '.join(ps)
+
+    tokens = textclenaer(ps)
+    tokens.insert(0, 0)
+    tokens = torch.LongTensor(tokens).to(device).unsqueeze(0)
+
+    ref_text = ref_text.strip()
+    ps = global_phonemizer.phonemize([ref_text])
+    ps = word_tokenize(ps[0])
+    ps = ' '.join(ps)
+
+    ref_tokens = textclenaer(ps)
+    ref_tokens.insert(0, 0)
+    ref_tokens = torch.LongTensor(ref_tokens).to(device).unsqueeze(0)
+
+
+    with torch.no_grad():
+        input_lengths = torch.LongTensor([tokens.shape[-1]]).to(device)
+        text_mask = length_to_mask(input_lengths).to(device)
+
+        t_en = model.text_encoder(tokens, input_lengths, text_mask)
+        bert_dur = model.bert(tokens, attention_mask=(~text_mask).int())
+        d_en = model.bert_encoder(bert_dur).transpose(-1, -2)
+
+        ref_input_lengths = torch.LongTensor([ref_tokens.shape[-1]]).to(device)
+        ref_text_mask = length_to_mask(ref_input_lengths).to(device)
+        ref_bert_dur = model.bert(ref_tokens, attention_mask=(~ref_text_mask).int())
+        s_pred = sampler(noise = torch.randn((1, 256)).unsqueeze(1).to(device),
+                                          embedding=bert_dur,
+                                          embedding_scale=embedding_scale,
+                                            features=ref_s, # reference from the same speaker as the embedding
+                                             num_steps=diffusion_steps).squeeze(1)
+
+
+        s = s_pred[:, 128:]
+        ref = s_pred[:, :128]
+
+        ref = alpha * ref + (1 - alpha)  * ref_s[:, :128]
+        s = beta * s + (1 - beta)  * ref_s[:, 128:]
+
+        d = model.predictor.text_encoder(d_en,
+                                         s, input_lengths, text_mask)
+
+        x, _ = model.predictor.lstm(d)
+        duration = model.predictor.duration_proj(x)
+
+        duration = torch.sigmoid(duration).sum(axis=-1)
+        pred_dur = torch.round(duration.squeeze()).clamp(min=1)
+
+
+        pred_aln_trg = torch.zeros(input_lengths, int(pred_dur.sum().data))
+        c_frame = 0
+        for i in range(pred_aln_trg.size(0)):
+            pred_aln_trg[i, c_frame:c_frame + int(pred_dur[i].data)] = 1
+            c_frame += int(pred_dur[i].data)
+
+        # encode prosody
+        en = (d.transpose(-1, -2) @ pred_aln_trg.unsqueeze(0).to(device))
+        if model_params.decoder.type == "hifigan":
+            asr_new = torch.zeros_like(en)
+            asr_new[:, :, 0] = en[:, :, 0]
+            asr_new[:, :, 1:] = en[:, :, 0:-1]
+            en = asr_new
+
+        F0_pred, N_pred = model.predictor.F0Ntrain(en, s)
+
+        asr = (t_en @ pred_aln_trg.unsqueeze(0).to(device))
+        if model_params.decoder.type == "hifigan":
+            asr_new = torch.zeros_like(asr)
+            asr_new[:, :, 0] = asr[:, :, 0]
+            asr_new[:, :, 1:] = asr[:, :, 0:-1]
+            asr = asr_new
+
+        out = model.decoder(asr,
+                                F0_pred, N_pred, ref.squeeze().unsqueeze(0))
+
+
+    return out.squeeze().cpu().numpy()[..., :-50] # weird pulse at the end of the model, need to be fixed later

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,8 @@ einops-exts
 tqdm
 typing
 typing-extensions
-git+https://github.com/resemble-ai/monotonic_align.git
+git+https://github.com/resemble-ai/monotonic_align.git # or resemble-monotonic-align
+gradio
+phonemizer
+cached-path
+tortoise-tts # for the Gradio demo, splitting text


### PR DESCRIPTION
Please see updated README for details. Requested by multiple people.

Note: I will be updating the HF space more often since I have direct push access, but I'll try to make PRs occasionally to keep it up-to-date

> ## Python API
> 
> You can now use StyleTTS 2 directly in your programs! A `pip`-compatible package is coming soon.
> 
> Multi-Speaker Inference:
> 
> ```python
> from scipy.io.wavfile import write
> import msinference
> text = 'Hello world!'
> voice = msinference.compute_style('voice.wav')
> wav = msinference.inference(text, voice, alpha=0.3, beta=0.7, diffusion_steps=7, embedding_scale=1)
> write('result.wav', 24000, wav)
> ```
> 
> LJSpeech Inference:
> 
> ```python
> from scipy.io.wavfile import write
> import ljinference
> text = 'Hello world!'
> noise = torch.randn(1,1,256).to('cuda' if torch.cuda.is_available() else 'cpu')
> wav = ljinference.inference(text, noise, diffusion_steps=7, embedding_scale=1)
> write('result.wav', 24000, wav)
> ```
> 
> For longer text, you can [help implement #54](https://github.com/yl4579/StyleTTS2/issues/54) or use Tortoise TTS for splitting:
> 
> ```python
> from tortoise.utils.text import split_and_recombine_text
> import numpy as np
> from scipy.io.wavfile import write
> import msinference
> text = 'Long text here...'
> texts = split_and_recombine_text(text)
> audios = []
> voice = msinference.compute_style('voice.wav')
> for t in progress.tqdm(texts):
>     audios.append(styletts2importable.inference(t, voice, alpha=0.3, beta=0.7, diffusion_steps=7, embedding_scale=1))
> write('result.wav', 24000, np.concatenate(audios))
> ```
> 
> ## GUI
> 
> You can run inference (finetuning coming soon) on a GUI based on the [online demo](https://huggingface.co/spaces/styletts2/styletts2) powered by Gradio.
> 
> ```bash
> python app.py
> ```
> 
> **NOTE: Only the multi-speaker tab supports long-text currently.**
> 
> Note: the online demo will be updated more frequently as changes are pushed directly to it (rather than through PRs). If you would like to use the latest (potentially unstable) version, use Docker:
> 
> ```bash
> docker run -it -p 7860:7860 --platform=linux/amd64 --gpus all registry.hf.space/styletts2-styletts2:latest python app.py
> ``

